### PR TITLE
Fixes CBG-Centrum-voor-familiegeschiedenis/PiCo #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.md)
+[![nl](https://img.shields.io/badge/lang-nl-blue.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.nl.md)
+
 ## PiCo
 This is the repository for **Persons in Context (PiCo)**, the intended successor to the *Archive to Archive* (A2A) data model. PiCo will be a new standard based on the principles of Linked Open Data. 
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-#PiCo
-
+## PiCO
 This is the repository for **Persons in Context (PiCo)**, the intended successor to the *Archive to Archive* (A2A) data model. PiCo will be a new standard based on the principles of Linked Open Data. 
 
 ## Purpose

--- a/README.md
+++ b/README.md
@@ -1,61 +1,60 @@
-# PiCo
+#PiCo
 
-Dit is de repository voor **Persons in Context (PiCo)**, de beoogde opvolger van het *Archive to Archive* (A2A) datamodel. PiCo wordt een nieuwe standaard volgens de uitgangsprincipes van Linked Open Data. 
+This is the repository for **Persons in Context (PiCo)**, the intended successor to the *Archive to Archive* (A2A) data model. PiCo will be a new standard based on the principles of Linked Open Data. 
 
-## Doel
-Het [CBG](https://cbg.nl) wil komen tot een **toepasbaar applicatieprofiel** voor Personen en Gebeurtenissen. Voor haar **eigen collecties**, maar ook als nieuwe standaard voor **[WieWasWie](https://wiewaswie.nl)**.
+## Purpose
+The [CBG](https://cbg.nl) wants to achieve an **applicable application profile** for persons and events. For its **own collections**, but also as a new standard for **[WhoWasWie](https://wiewaswie.nl)**.
 
-Wat wil het CBG met de nieuwe standaard:
-- Het primaire doel is kunnen zoeken naar personen. Personen moeten uniek identificeerbaar zijn en gelinkt aan één of meerdere bronnen en gebeurtenissen.	
-- Daarnaast moet het mogelijk zijn om op een gestandaardiseerde manier relaties te leggen tussen uniek identificeerbare personen.
+What does the CBG want from the new standard?
+- The primary goal is to be able to search for people. People must be uniquely identifiable and linked to one or more sources and events.	
+- It must also be possible to establish relationships between uniquely identifiable persons in a standardised way.
 
-## Uitgangspunten
-Voor de nieuw te ontwikkelen standaard, gelden de volgende uitgangspunten: 
-- We maken gebruik maken Linked Data technologie. Daarbij gebruiken we zo veel mogelijk bestaande ontologieën.
-- Conversie van A2A naar PiCo moet zo veel mogelijk geautomatiseerd mogelijk zijn. Partijen die nog niet in staat zijn om PiCO te genereren, moeten kunnen (blijven) deelnemen aan WieWasWie. 
-- We maken onderscheid tussen persoonsvermeldingen (een naam van een persoon die voorkomt in een bron) en personen (een uniek persoon, die gekoppeld kan zijn aan meerdere persoonsvermeldingen). 
-- Het moet mogelijk zijn om metadata vast te leggen over links tussen personen of persoonsvermeldingen. Bijvoorbeeld: “*Op basis van bron B1 stellen we dat de persoonsvermeldingen PV1 en PV2 beiden horen bij persoon P1.*” Of: “*Op basis van bron B2 stellen we dat persoon P1 de vader is van persoon P2*”. 
-- De standaard moet flexibel zijn. Geschikt voor 10 jaar. Maar niet per se in steen gehouwen voor die periode. 
-- De standaard moet uitbreidbaar zijn. De doelstelling van het CBG (zoeken naar voorouders), moet geen beperking zijn voor andere onderzoeksdoeleinden. 
+## Starting points
+The following starting points apply to the new standard to be developed: 
+- We use Linked Data technology. We will use existing ontologies as much as possible.
+- The conversion from A2A to PiCo should be as automated as possible. Parties that are not yet able to generate PiCo must be able to (continue to) participate in WieWasWie. 
+- We distinguish between person records (a name of a person that appears in a source) and persons (a unique person that can be linked to several person records). 
+- It should be possible to record metadata about links between persons or person mentions. For example, "*Based on source S1, we note that person observations PO1 and PO2 both belong to person P1.*". Or: "*Based on source S2, we state that person P1 is the father of person P2*". 
+- The standard should be flexible. Suitable for 10 years. But not necessarily set in stone for that period. 
+- The standard must be extensible. The purpose of CBG (to find ancestors) should not be a limitation for other research purposes. 
 
-## Verbeterpunten ten opzichte van het huidige A2A-model
-Het huidige A2A-model schiet op een aantal punten te kort. Een aantal knelpunten van het model zijn: 
-- A2A kent geen uniek identificeerbare personen, waardoor het leggen van relaties tussen personen lastig is: 
-- A2A gaat eigenlijk over persoonsvermeldingen, en niet over personen. 
-- A2A kent wel een identifier per persoonsvermelding, maar die is bedoeld om relaties te leggen tussen persoonsvermeldingen binnen één bron. 
-- A2A is onvoldoende genormaliseerd: 
-- Bij een persoon wordt bijvoorbeeld zijn verblijfplaats, beroep en leeftijd vermeld. Dat zijn geen van allen vaste (identificeerbare) kenmerk van een persoon (maar wel van de persoonsvermelding). 
-- A2A maakt geen gebruik van bestaande thesauri. Bijvoorbeeld voor plaatsnamen, event types of voor type relaties. 
-- A2A definieert eigenschappen waar al breed geaccepteerde standaarden voor bestaan. Bijvoorbeeld het element Bron. Dit zou goed vervangen kunnen worden door elementen uit, bijvoorbeeld, [Records in Contexts](https://www.ica.org/en/records-in-contexts-ontology). 
+## Improvements to the current A2A model
+The current A2A model falls short in a number of ways. Some of the model's bottlenecks are 
+- A2A has no uniquely identifiable individuals, which makes it difficult to establish relationships between individuals: 
+- A2A is really about person identifiers, not people. 
+- A2A does have an identifier per person record, but this is intended to establish relationships between person records within a single source. 
+- A2A is not sufficiently standardised: 
+- For example, a person's place of residence, occupation and age are given. None of these are fixed (identifiable) characteristics of a person (but they are of the person record). 
+- A2A does not use existing thesauri. For example, for place names, event types or type relationships. 
+- A2A defines attributes for which widely accepted standards already exist. For example, the source element. This could well be replaced by elements from e.g. [Records in Contexts](https://www.ica.org/en/records-in-contexts-ontology). 
 
 ## Deliverables
-- Een uitwerking van het conceptuele datamodel voor PiCo (in tekst vorm). 
-- Een technische uitwerking van het applicatieprofiel in [Shapes Constraint Language](https://www.w3.org/TR/shacl/) (SHACL). 
-- Voorbeelden voor de toepassing van het model. 
-- Een plan voor het uitrollen van het applicatieprofiel in het veld, inclusief: 
-  - Communicatiestrategie 
-  - Organisatiestructuur voor het beheer van het applicatieprofiel 
-  - Wijze van publicatie 
+- An elaboration of the conceptual data model for PiCo (in text form). 
+- A technical elaboration of the application profile in [Shapes Constraint Language](https://www.w3.org/TR/shacl/) (SHACL). 
+- Examples of the application of the model. 
+- A plan for the roll-out of the application profile in the field, including 
+  - Communication strategy 
+  - Organisational structure for managing the application profile 
+  - Mode of publication 
 
-Alle deliverables worden in eerste instantie in het Nederlands opgesteld. Indien nodig, kunnen deze later vertaald worden naar het Engels. 
+All deliverables will initially be produced in Dutch. If necessary, they can later be translated into English. 
 
-## Erkenning
-PiCo is geïnspireerd op de [ROAR](https://leonvanwissen.nl/vocab/roar/docs/) ontologie voor Reconstructions and Observations in Archival Resources.\
-ROAR is ontwikkeld door:
+## Acknowledgements
+PiCo is inspired by the [ROAR](https://leonvanwissen.nl/vocab/roar/docs/) ontology for Reconstructions and Observations in Archival Resources.
+ROAR was developed by
 * Menno den Engelse, ([Islands of Meaning, The Netherlands](https://islandsofmeaning.nl/))
 * Leon van Wissen, ([University of Amsterdam, The Netherlands](https://www.uva.nl/over-de-uva/organisatie/faculteiten/faculteit-der-geesteswetenschappen/faculteit-der-geesteswetenschappen.html))
 
 
-## Licentie
+## License
 
-Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
+Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa].
 
 This work is licensed under a
 [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
 
-[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa].
 
 [cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## PiCO
+## PiCo
 This is the repository for **Persons in Context (PiCo)**, the intended successor to the *Archive to Archive* (A2A) data model. PiCo will be a new standard based on the principles of Linked Open Data. 
 
 ## Purpose

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,0 +1,61 @@
+# PiCo
+
+Dit is de repository voor **Persons in Context (PiCo)**, de beoogde opvolger van het *Archive to Archive* (A2A) datamodel. PiCo wordt een nieuwe standaard volgens de uitgangsprincipes van Linked Open Data. 
+
+## Doel
+Het [CBG](https://cbg.nl) wil komen tot een **toepasbaar applicatieprofiel** voor Personen en Gebeurtenissen. Voor haar **eigen collecties**, maar ook als nieuwe standaard voor **[WieWasWie](https://wiewaswie.nl)**.
+
+Wat wil het CBG met de nieuwe standaard:
+- Het primaire doel is kunnen zoeken naar personen. Personen moeten uniek identificeerbaar zijn en gelinkt aan één of meerdere bronnen en gebeurtenissen.	
+- Daarnaast moet het mogelijk zijn om op een gestandaardiseerde manier relaties te leggen tussen uniek identificeerbare personen.
+
+## Uitgangspunten
+Voor de nieuw te ontwikkelen standaard, gelden de volgende uitgangspunten: 
+- We maken gebruik maken Linked Data technologie. Daarbij gebruiken we zo veel mogelijk bestaande ontologieën.
+- Conversie van A2A naar PiCo moet zo veel mogelijk geautomatiseerd mogelijk zijn. Partijen die nog niet in staat zijn om PiCO te genereren, moeten kunnen (blijven) deelnemen aan WieWasWie. 
+- We maken onderscheid tussen persoonsvermeldingen (een naam van een persoon die voorkomt in een bron) en personen (een uniek persoon, die gekoppeld kan zijn aan meerdere persoonsvermeldingen). 
+- Het moet mogelijk zijn om metadata vast te leggen over links tussen personen of persoonsvermeldingen. Bijvoorbeeld: “*Op basis van bron B1 stellen we dat de persoonsvermeldingen PV1 en PV2 beiden horen bij persoon P1.*” Of: “*Op basis van bron B2 stellen we dat persoon P1 de vader is van persoon P2*”. 
+- De standaard moet flexibel zijn. Geschikt voor 10 jaar. Maar niet per se in steen gehouwen voor die periode. 
+- De standaard moet uitbreidbaar zijn. De doelstelling van het CBG (zoeken naar voorouders), moet geen beperking zijn voor andere onderzoeksdoeleinden. 
+
+## Verbeterpunten ten opzichte van het huidige A2A-model
+Het huidige A2A-model schiet op een aantal punten te kort. Een aantal knelpunten van het model zijn: 
+- A2A kent geen uniek identificeerbare personen, waardoor het leggen van relaties tussen personen lastig is: 
+- A2A gaat eigenlijk over persoonsvermeldingen, en niet over personen. 
+- A2A kent wel een identifier per persoonsvermelding, maar die is bedoeld om relaties te leggen tussen persoonsvermeldingen binnen één bron. 
+- A2A is onvoldoende genormaliseerd: 
+- Bij een persoon wordt bijvoorbeeld zijn verblijfplaats, beroep en leeftijd vermeld. Dat zijn geen van allen vaste (identificeerbare) kenmerk van een persoon (maar wel van de persoonsvermelding). 
+- A2A maakt geen gebruik van bestaande thesauri. Bijvoorbeeld voor plaatsnamen, event types of voor type relaties. 
+- A2A definieert eigenschappen waar al breed geaccepteerde standaarden voor bestaan. Bijvoorbeeld het element Bron. Dit zou goed vervangen kunnen worden door elementen uit, bijvoorbeeld, [Records in Contexts](https://www.ica.org/en/records-in-contexts-ontology). 
+
+## Deliverables
+- Een uitwerking van het conceptuele datamodel voor PiCo (in tekst vorm). 
+- Een technische uitwerking van het applicatieprofiel in [Shapes Constraint Language](https://www.w3.org/TR/shacl/) (SHACL). 
+- Voorbeelden voor de toepassing van het model. 
+- Een plan voor het uitrollen van het applicatieprofiel in het veld, inclusief: 
+  - Communicatiestrategie 
+  - Organisatiestructuur voor het beheer van het applicatieprofiel 
+  - Wijze van publicatie 
+
+Alle deliverables worden in eerste instantie in het Nederlands opgesteld. Indien nodig, kunnen deze later vertaald worden naar het Engels. 
+
+## Erkenning
+PiCo is geïnspireerd op de [ROAR](https://leonvanwissen.nl/vocab/roar/docs/) ontologie voor Reconstructions and Observations in Archival Resources.\
+ROAR is ontwikkeld door:
+* Menno den Engelse, ([Islands of Meaning, The Netherlands](https://islandsofmeaning.nl/))
+* Leon van Wissen, ([University of Amsterdam, The Netherlands](https://www.uva.nl/over-de-uva/organisatie/faculteiten/faculteit-der-geesteswetenschappen/faculteit-der-geesteswetenschappen.html))
+
+
+## Licentie
+
+Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
+
+This work is licensed under a
+[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+
+[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
+[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
+

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,5 +1,6 @@
-[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.md)
 [![nl](https://img.shields.io/badge/lang-nl-blue.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.nl.md)
+[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.md)
+
 
 ## PiCo
 

--- a/README.nl.md
+++ b/README.nl.md
@@ -1,4 +1,7 @@
-# PiCo
+[![en](https://img.shields.io/badge/lang-en-red.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.md)
+[![nl](https://img.shields.io/badge/lang-nl-blue.svg)](https://github.com/CBG-Centrum-voor-familiegeschiedenis/PiCo/blob/main/README.nl.md)
+
+## PiCo
 
 Dit is de repository voor **Persons in Context (PiCo)**, de beoogde opvolger van het *Archive to Archive* (A2A) datamodel. PiCo wordt een nieuwe standaard volgens de uitgangsprincipes van Linked Open Data. 
 


### PR DESCRIPTION
Issue #11 requests an English readme. By default on GitHub the readme is in English (like the file name!). I have followed this [community recommendation]() to have the readme in multiple languages (see this [example]()).

The translation has been made with [Deepl](https://deepl.com)(credits to to the [Royal Academy of Arts and Sciences](https://www.knaw.nl) for providing the license) and further enhances with their language wizard. Additionally, I have made some manual changes re the more expert terms.